### PR TITLE
include table name in DEFAULT-constraint names in MSSQL

### DIFF
--- a/pysqlsync/dialect/mssql/object_types.py
+++ b/pysqlsync/dialect/mssql/object_types.py
@@ -17,7 +17,7 @@ class MSSQLColumn(Column):
     def default_constraint_name(self) -> LocalId:
         "The name of the constraint for DEFAULT."
 
-        return LocalId(f"df_{self.name.local_id}")
+        return LocalId(f"df_{self.table_name.local_id}_{self.name.local_id}")
 
     @property
     def data_spec(self) -> str:

--- a/pysqlsync/dialect/mysql/discovery.py
+++ b/pysqlsync/dialect/mysql/discovery.py
@@ -90,6 +90,7 @@ class MySQLExplorer(AnsiExplorer):
         for col in column_meta:
             columns.append(
                 self.factory.column_class(
+                    table_id,
                     LocalId(col.column_name),
                     self.discovery.sql_data_type_from_spec(
                         type_name=col.data_type,

--- a/pysqlsync/dialect/oracle/discovery.py
+++ b/pysqlsync/dialect/oracle/discovery.py
@@ -152,6 +152,7 @@ class OracleExplorer(Explorer):
             identity = bool(col.is_identity)
             columns.append(
                 self.factory.column_class(
+                    table_id,
                     LocalId(col.column_name),
                     data_type,
                     nullable,

--- a/pysqlsync/dialect/postgresql/discovery.py
+++ b/pysqlsync/dialect/postgresql/discovery.py
@@ -277,6 +277,7 @@ class PostgreSQLExplorer(Explorer):
                 data_type = SqlArrayType(data_type)
             columns.append(
                 self.factory.column_class(
+                    table_id,
                     LocalId(col.column_name),
                     data_type,
                     bool(col.is_nullable),

--- a/pysqlsync/formation/discovery.py
+++ b/pysqlsync/formation/discovery.py
@@ -183,6 +183,7 @@ class AnsiExplorer(Explorer):
             column_name, data_type, nullable = col
             columns.append(
                 self.factory.column_class(
+                    table_id,
                     LocalId(column_name),
                     self.discovery.sql_data_type_from_spec(type_name=data_type),
                     bool(nullable),
@@ -211,6 +212,7 @@ class AnsiExplorer(Explorer):
         for col in column_meta:
             columns.append(
                 self.factory.column_class(
+                    table_id,
                     LocalId(col.column_name),
                     self.discovery.sql_data_type_from_spec(
                         type_name=col.data_type,

--- a/pysqlsync/formation/object_types.py
+++ b/pysqlsync/formation/object_types.py
@@ -184,6 +184,7 @@ class Column(DatabaseObject):
     """
     A column in a database table.
 
+    :param table_name: The name of the table that the column belongs to.
     :param name: The name of the column within its host table.
     :param data_type: The SQL data type of the column.
     :param nullable: True if the column can take the value NULL.
@@ -192,6 +193,7 @@ class Column(DatabaseObject):
     :param description: The textual description of the column.
     """
 
+    table_name: SupportsQualifiedId
     name: LocalId
     data_type: SqlDataType
     nullable: bool

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -47,9 +47,13 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
-                Column(LocalId("city"), SqlVariableCharacterType(), False),
-                Column(LocalId("state"), SqlVariableCharacterType(), True),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
+                Column(
+                    table_def.name, LocalId("city"), SqlVariableCharacterType(), False
+                ),
+                Column(
+                    table_def.name, LocalId("state"), SqlVariableCharacterType(), True
+                ),
             ],
         )
 
@@ -58,32 +62,37 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
                 Column(
+                    table_def.name,
                     LocalId("integer_8"),
                     SqlIntegerType(2),
                     False,
                     default="127",
                 ),
                 Column(
+                    table_def.name,
                     LocalId("integer_16"),
                     SqlIntegerType(2),
                     False,
                     default="32767",
                 ),
                 Column(
+                    table_def.name,
                     LocalId("integer_32"),
                     SqlIntegerType(4),
                     False,
                     default="2147483647",
                 ),
                 Column(
+                    table_def.name,
                     LocalId("integer_64"),
                     SqlIntegerType(8),
                     False,
                     default="0",
                 ),
                 Column(
+                    table_def.name,
                     LocalId("integer"),
                     SqlIntegerType(8),
                     False,
@@ -97,8 +106,19 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False, identity=True),
-                Column(LocalId("unique"), SqlVariableCharacterType(64), False),
+                Column(
+                    table_def.name,
+                    LocalId("id"),
+                    SqlIntegerType(8),
+                    False,
+                    identity=True,
+                ),
+                Column(
+                    table_def.name,
+                    LocalId("unique"),
+                    SqlVariableCharacterType(64),
+                    False,
+                ),
             ],
         )
         self.assertListEqual(
@@ -113,14 +133,16 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
                 Column(
+                    table_def.name,
                     LocalId("name"),
                     SqlVariableCharacterType(),
                     False,
                     description="The person's full name.",
                 ),
                 Column(
+                    table_def.name,
                     LocalId("address"),
                     SqlIntegerType(8),
                     False,
@@ -134,9 +156,11 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlUuidType(), False),
-                Column(LocalId("name"), SqlVariableCharacterType(), False),
-                Column(LocalId("reports_to"), SqlUuidType(), False),
+                Column(table_def.name, LocalId("id"), SqlUuidType(), False),
+                Column(
+                    table_def.name, LocalId("name"), SqlVariableCharacterType(), False
+                ),
+                Column(table_def.name, LocalId("reports_to"), SqlUuidType(), False),
             ],
         )
 
@@ -148,13 +172,15 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
                 Column(
+                    table_def.name,
                     LocalId("state"),
                     SqlUserDefinedType(QualifiedId(None, "WorkflowState")),
                     False,
                 ),
                 Column(
+                    table_def.name,
                     LocalId("optional_state"),
                     SqlUserDefinedType(QualifiedId(None, "WorkflowState")),
                     True,
@@ -173,9 +199,11 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
-                Column(LocalId("state"), SqlIntegerType(4), False),
-                Column(LocalId("optional_state"), SqlIntegerType(4), True),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
+                Column(table_def.name, LocalId("state"), SqlIntegerType(4), False),
+                Column(
+                    table_def.name, LocalId("optional_state"), SqlIntegerType(4), True
+                ),
             ],
         )
         enum_name = tables.ExtensibleEnum.__name__
@@ -183,9 +211,18 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(enum_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(4), False, identity=True),
                 Column(
-                    LocalId("value"), SqlVariableCharacterType(ENUM_NAME_LENGTH), False
+                    enum_def.name,
+                    LocalId("id"),
+                    SqlIntegerType(4),
+                    False,
+                    identity=True,
+                ),
+                Column(
+                    enum_def.name,
+                    LocalId("value"),
+                    SqlVariableCharacterType(ENUM_NAME_LENGTH),
+                    False,
                 ),
             ],
         )
@@ -222,9 +259,11 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
-                Column(LocalId("state"), SqlIntegerType(4), False),
-                Column(LocalId("optional_state"), SqlIntegerType(4), True),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
+                Column(table_def.name, LocalId("state"), SqlIntegerType(4), False),
+                Column(
+                    table_def.name, LocalId("optional_state"), SqlIntegerType(4), True
+                ),
             ],
         )
         enum_name = tables.WorkflowState.__name__
@@ -232,9 +271,18 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(enum_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(4), False, identity=True),
                 Column(
-                    LocalId("value"), SqlVariableCharacterType(ENUM_NAME_LENGTH), False
+                    enum_def.name,
+                    LocalId("id"),
+                    SqlIntegerType(4),
+                    False,
+                    identity=True,
+                ),
+                Column(
+                    enum_def.name,
+                    LocalId("value"),
+                    SqlVariableCharacterType(ENUM_NAME_LENGTH),
+                    False,
                 ),
             ],
         )
@@ -271,9 +319,11 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
-                Column(LocalId("country"), SqlIntegerType(4), False),
-                Column(LocalId("optional_country"), SqlIntegerType(4), True),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
+                Column(table_def.name, LocalId("country"), SqlIntegerType(4), False),
+                Column(
+                    table_def.name, LocalId("optional_country"), SqlIntegerType(4), True
+                ),
             ],
         )
         enum_name = country.CountryEnum.__name__
@@ -282,17 +332,20 @@ class TestConverter(unittest.TestCase):
             list(enum_def.columns.values()),
             [
                 Column(
+                    enum_def.name,
                     LocalId("id"),
                     SqlIntegerType(4),
                     False,
                     identity=True,
                 ),
                 Column(
+                    enum_def.name,
                     LocalId("iso_code"),
                     SqlVariableCharacterType(),
                     False,
                 ),
                 Column(
+                    enum_def.name,
                     LocalId("name"),
                     SqlVariableCharacterType(),
                     False,
@@ -326,23 +379,27 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
                 Column(
+                    table_def.name,
                     LocalId("single"),
                     SqlFixedCharacterType(limit=5),
                     False,
                 ),
                 Column(
+                    table_def.name,
                     LocalId("multiple"),
                     SqlFixedCharacterType(limit=4),
                     False,
                 ),
                 Column(
+                    table_def.name,
                     LocalId("union"),
                     SqlVariableCharacterType(limit=255),
                     False,
                 ),
                 Column(
+                    table_def.name,
                     LocalId("unbounded"),
                     SqlVariableCharacterType(),
                     False,
@@ -374,8 +431,9 @@ class TestConverter(unittest.TestCase):
         self.assertListEqual(
             list(table_def.columns.values()),
             [
-                Column(LocalId("id"), SqlIntegerType(8), False),
+                Column(table_def.name, LocalId("id"), SqlIntegerType(8), False),
                 Column(
+                    table_def.name,
                     LocalId("coords"),
                     SqlUserDefinedType(
                         QualifiedId("sample", tables.Coordinates.__name__)
@@ -457,6 +515,7 @@ class TestConverter(unittest.TestCase):
         user_table.columns["homepage_url"].nullable = False
         user_table.columns.add(
             Column(
+                user_table.name,
                 LocalId("social_url"),
                 SqlVariableCharacterType(),
                 False,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -109,11 +109,11 @@ class TestGenerator(TestEngineBase, unittest.TestCase):
             tables.DefaultBooleanTable,
             'CREATE TABLE "DefaultBooleanTable" (\n'
             '"id" bigint NOT NULL,\n'
-            '"boolean_false" bit NOT NULL CONSTRAINT "df_boolean_false" DEFAULT 0,\n'
-            '"boolean_true" bit NOT NULL CONSTRAINT "df_boolean_true" DEFAULT 1,\n'
+            '"boolean_false" bit NOT NULL CONSTRAINT "df_DefaultBooleanTable_boolean_false" DEFAULT 0,\n'
+            '"boolean_true" bit NOT NULL CONSTRAINT "df_DefaultBooleanTable_boolean_true" DEFAULT 1,\n'
             '"nullable_boolean_null" bit,\n'
-            '"nullable_boolean_false" bit CONSTRAINT "df_nullable_boolean_false" DEFAULT 0,\n'
-            '"nullable_boolean_true" bit CONSTRAINT "df_nullable_boolean_true" DEFAULT 1,\n'
+            '"nullable_boolean_false" bit CONSTRAINT "df_DefaultBooleanTable_nullable_boolean_false" DEFAULT 0,\n'
+            '"nullable_boolean_true" bit CONSTRAINT "df_DefaultBooleanTable_nullable_boolean_true" DEFAULT 1,\n'
             'CONSTRAINT "pk_DefaultBooleanTable" PRIMARY KEY ("id")\n'
             ");",
         )
@@ -172,11 +172,11 @@ class TestGenerator(TestEngineBase, unittest.TestCase):
             tables.DefaultNumericTable,
             'CREATE TABLE "DefaultNumericTable" (\n'
             '"id" bigint NOT NULL,\n'
-            '"integer_8" smallint NOT NULL CONSTRAINT "df_integer_8" DEFAULT 127,\n'
-            '"integer_16" smallint NOT NULL CONSTRAINT "df_integer_16" DEFAULT 32767,\n'
-            '"integer_32" integer NOT NULL CONSTRAINT "df_integer_32" DEFAULT 2147483647,\n'
-            '"integer_64" bigint NOT NULL CONSTRAINT "df_integer_64" DEFAULT 0,\n'
-            '"integer" bigint NOT NULL CONSTRAINT "df_integer" DEFAULT 23,\n'
+            '"integer_8" smallint NOT NULL CONSTRAINT "df_DefaultNumericTable_integer_8" DEFAULT 127,\n'
+            '"integer_16" smallint NOT NULL CONSTRAINT "df_DefaultNumericTable_integer_16" DEFAULT 32767,\n'
+            '"integer_32" integer NOT NULL CONSTRAINT "df_DefaultNumericTable_integer_32" DEFAULT 2147483647,\n'
+            '"integer_64" bigint NOT NULL CONSTRAINT "df_DefaultNumericTable_integer_64" DEFAULT 0,\n'
+            '"integer" bigint NOT NULL CONSTRAINT "df_DefaultNumericTable_integer" DEFAULT 23,\n'
             'CONSTRAINT "pk_DefaultNumericTable" PRIMARY KEY ("id")\n'
             ");",
         )
@@ -328,7 +328,7 @@ class TestGenerator(TestEngineBase, unittest.TestCase):
             tables.DefaultDateTimeTable,
             'CREATE TABLE "DefaultDateTimeTable" (\n'
             '"id" bigint NOT NULL,\n'
-            """"iso_date_time" datetime2 NOT NULL CONSTRAINT "df_iso_date_time" DEFAULT '1989-10-24 23:59:59',\n"""
+            """"iso_date_time" datetime2 NOT NULL CONSTRAINT "df_DefaultDateTimeTable_iso_date_time" DEFAULT '1989-10-24 23:59:59',\n"""
             'CONSTRAINT "pk_DefaultDateTimeTable" PRIMARY KEY ("id")\n'
             ");",
         )


### PR DESCRIPTION
Hi Levente,

Issue in MSSQL: the DEFAULT-constraint-name generated by `pysqlsync` is not table-specific which prevents the creation of multiple tables with the same column-name and those columns having default values.

Example:
Python dataclasses:
```Python
@dataclass
class Table1:
    id: PrimaryKey[int]
    boolean_field: bool = False

@dataclass
class Table2:
    id: PrimaryKey[int]
    boolean_field: bool = False
```

When creating DB tables for these classes in MSSQL, the column definition of the boolean column looks like this for both of the tables:
```sql
"boolean_field" bit NOT NULL CONSTRAINT "df_boolean_field" DEFAULT 0
```

The problem is that `df_boolean_field` is not unique, and will cause an error when attempting to create the second table in the database, like `There is already an object named 'df_boolean_field' in the database.`.

In this PR I change the generated constraint name to include the table name as well. So the constraints in the previous example would be generated with these names: `df_Table1_boolean_field` and `df_Table2_boolean_field`, which are now unique.

To be able to include the table name in the constraint, I added the `table_name` field to the `Column` dataclass (see pysqlsync/formation/object_types.py), which can be utilized in `MSSQLColumn` (see pysqlsync/dialect/mssql/object_types.py). Let me know if this is not desired, or propose a better solution.